### PR TITLE
Make bluebinder_post.sh look for ro.vendor.bt.bdaddr_path as well

### DIFF
--- a/bluebinder_post.sh
+++ b/bluebinder_post.sh
@@ -14,6 +14,11 @@ mkdir -p /var/lib/bluetooth
 
 # Getting address file from properties
 bt_addr_file=$(/usr/bin/getprop ro.bt.bdaddr_path)
+
+if [ "$bt_addr_file" = "" ]; then
+    bt_addr_file=$(/usr/bin/getprop ro.vendor.bt.bdaddr_path)
+fi
+
 if [ "$bt_addr_file" != "" ]; then
     if ! cp $bt_addr_file /var/lib/bluetooth/board-address; then
         echo "Failed to copy $bt_addr_file."


### PR DESCRIPTION
Fixes upstream issue https://github.com/mer-hybris/bluebinder/issues/17 until it is fixed there.